### PR TITLE
Improve training robustness and memory usage

### DIFF
--- a/training/dataset.py
+++ b/training/dataset.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Tuple
+from typing import Sequence
 import numpy as np
 import torch
 from torch.utils.data import Dataset
@@ -20,8 +20,9 @@ class Sample:
 
 
 class ReplayDataset(Dataset):
-    def __init__(self, samples: List[Sample]):
-        self.samples = samples
+    def __init__(self, samples: Sequence[Sample]):
+        # copy to list to avoid external mutation during training
+        self.samples = list(samples)
 
     def __len__(self) -> int:
         return len(self.samples)


### PR DESCRIPTION
## Summary
- Allow `training/train.py` to run without GPUs by choosing `gloo` backend and CPU device when CUDA is unavailable
- Add configurable `--replay_size` and use a deque-based replay buffer to cap memory growth
- Make `ReplayDataset` accept generic sequences for flexible replay buffer inputs

## Testing
- `python training/train.py --out /tmp/out --channels 8 --blocks 1 --batch_size 2 --selfplay_steps 1 --epochs 1 --mcts_sims 1 --mcts_batch 1 --max_moves 1 --segment_k 1 --envs_per_rank 1 --replay_size 10 --temp 1 --lr 0.01`

------
https://chatgpt.com/codex/tasks/task_e_68969c6bb4008321b9d1eb2ef850c9d0